### PR TITLE
Home: add Franz Josef Allmayer to team

### DIFF
--- a/app/[locale]/home-page-client.tsx
+++ b/app/[locale]/home-page-client.tsx
@@ -481,8 +481,30 @@ export function HomePageClient() {
                 </div>
               </AnimatedElement>
 
-              {/* Clara Gromaches */}
+              {/* Franz Josef Allmayer */}
               <AnimatedElement animation="fade-in" delay={200}>
+                <div className="text-left">
+                  <div className="flex justify-between items-start mb-2">
+                    <h3 className="text-2xl font-bold text-black">Franz Josef Allmayer</h3>
+                    <div className="flex gap-3 ml-4">
+                      <a
+                        href="https://www.linkedin.com/in/franz-josef-allmayer"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-gray-600 hover:text-black transition-colors"
+                      >
+                        <img src="/linkedin.svg" alt="LinkedIn" className="w-5 h-5" />
+                      </a>
+                    </div>
+                  </div>
+                  <p className="text-sm text-gray-500 leading-relaxed">
+                    Franz works on digital infrastructure for decentralised governance and regenerative finance. He builds infrastructure to govern, finance, and verify impacts at internet scale at ixo, and contributes to Hypha developing tools for community-led economies and bioregional currencies such as SEEDS. He also founded Integrity.Earth, an independent think-and-do tank for regenerative development.
+                  </p>
+                </div>
+              </AnimatedElement>
+
+              {/* Clara Gromaches */}
+              <AnimatedElement animation="fade-in" delay={300}>
                 <div className="text-left">
                   <div className="flex justify-between items-start mb-2">
                     <a
@@ -501,13 +523,13 @@ export function HomePageClient() {
                     </a>
                   </div>
                   <p className="text-sm text-gray-500 leading-relaxed">
-                    Clara is a consultant, researcher and business operator on decentralised technologies. With a background in Architecture she developed regenerative housing projects, incubated cooperative housing projects, advised on affordable housing policy making to municipalities in Barcelona and manages operations at a decentralized tech workers cooperative.
+                    Clara is a consultant, researcher and business operator on decentralised technologies. With a background in Architecture she developed regenerative housing projects, incubated cooperative housing projects, advised on affordable housing policy making to municipalities in Barcelona and manages operations at a decentralised tech workers cooperative.
                   </p>
                 </div>
               </AnimatedElement>
 
               {/* Bradley C Royes */}
-              <AnimatedElement animation="fade-in" delay={300}>
+              <AnimatedElement animation="fade-in" delay={400}>
                 <div className="text-left">
                   <div className="flex justify-between items-start mb-2">
                     <h3 className="text-2xl font-bold text-black">Bradley Clark Royes</h3>
@@ -523,13 +545,13 @@ export function HomePageClient() {
                     </div>
                   </div>
                   <p className="text-sm text-gray-500 leading-relaxed">
-                    Bradley is a strategic designer and innovator working at the intersection of culture, AI-native systems, and human-centered technology. Currently the Node Manager for Foresight Institute's Berlin AI Node and leading AI Builders Berlin as Community Director, he brings experience design, blending applied research with grassroots organising and urban rituals.
+                    Bradley is a strategic designer and innovator working at the intersection of culture, AI-native systems, and human-centred technology. Currently the Node Manager for Foresight Institute's Berlin AI Node and leading AI Builders Berlin as Community Director, he brings experience design, blending applied research with grassroots organising and urban rituals.
                   </p>
                 </div>
               </AnimatedElement>
 
               {/* Livia Deschermayer */}
-              <AnimatedElement animation="fade-in" delay={400}>
+              <AnimatedElement animation="fade-in" delay={500}>
                 <div className="text-left">
                   <div className="flex justify-between items-start mb-2">
                     <h3 className="text-2xl font-bold text-black">Livia Deschermayer</h3>
@@ -545,13 +567,13 @@ export function HomePageClient() {
                     </div>
                   </div>
                   <p className="text-sm text-gray-500 leading-relaxed">
-                    Livia is an artist and published social researcher in the field of token engineering with deep practice on decentralized ecosystems within topics of governance, culture and incentivization. Her contributions include designing social system protocols and leading the Cultural Build initiative at Commons Stack.
+                    Livia is an artist and published social researcher in the field of token engineering with deep practice on decentralised ecosystems within topics of governance, culture and incentivisation. Her contributions include designing social system protocols and leading the Cultural Build initiative at Commons Stack.
                   </p>
                 </div>
               </AnimatedElement>
 
               {/* Jeff Emmett */}
-              <AnimatedElement animation="fade-in" delay={500}>
+              <AnimatedElement animation="fade-in" delay={600}>
                 <div className="text-left">
                   <div className="flex justify-between items-start mb-2">
                     <h3 className="text-2xl font-bold text-black">Jeff Emmett</h3>
@@ -575,7 +597,7 @@ export function HomePageClient() {
               </AnimatedElement>
 
               {/* Rita Palma */}
-              <AnimatedElement animation="fade-in" delay={600}>
+              <AnimatedElement animation="fade-in" delay={700}>
                 <div className="text-left">
                   <div className="flex justify-between items-start mb-2">
                     <a
@@ -594,13 +616,13 @@ export function HomePageClient() {
                     </a>
                   </div>
                   <p className="text-sm text-gray-500 leading-relaxed">
-                    Rita is an artist and researcher whose work centers on multispecies perspectives within organisational contexts. She explores the convergence of art and sustainability, developing creative and transdisciplinary experiences to challenge conventional paradigms and cultivate new imaginaries for transformative change.
+                    Rita is an artist and researcher whose work centres on multispecies perspectives within organisational contexts. She explores the convergence of art and sustainability, developing creative and transdisciplinary experiences to challenge conventional paradigms and cultivate new imaginaries for transformative change.
                   </p>
                 </div>
               </AnimatedElement>
 
               {/* Robert Matijević */}
-              <AnimatedElement animation="fade-in" delay={700}>
+              <AnimatedElement animation="fade-in" delay={800}>
                 <div className="text-left">
                   <div className="flex justify-between items-start mb-2">
                     <h3 className="text-2xl font-bold text-black">Robert Matijević</h3>

--- a/app/[locale]/team/charlie/page.tsx
+++ b/app/[locale]/team/charlie/page.tsx
@@ -28,7 +28,7 @@ export default function CharliePage() {
           <section>
             <h2 className="text-2xl font-semibold mb-4">About</h2>
             <p className="text-gray-300 mb-4">Berlin</p>
-            <p className="text-gray-300 mb-4">Charlie has been investigating novel models for investing in the commons since 2013, emphasizing the use of technology in the democratisation of investment and governance tools for public infrastructures such as housing. His work highlights the necessity of shifting away from top-down urban development models that primarily benefits private landowners and towards citizen-led investment approaches. Since 2021, Charlie has collaborated on developing modular smart contracts that utilize simple bonding curves, one of which was deployed in 2023 through the Swiss Association he co-founded in Switzerland. He most recently led the Civic Tech Studio at Dark Matter Labs in which prototyping work provided valuable insights into decentralised finance mechanisms. In October 2024, Charlie was awarded the Just Open Source Grant to further explore neighbourhood wealth mechanisms in Berlin co-operative developments through novel blockchain technologies.</p>
+            <p className="text-gray-300 mb-4">Charlie has been investigating novel models for investing in the commons since 2013, emphasising the use of technology in the democratisation of investment and governance tools for public infrastructures such as housing. His work highlights the necessity of shifting away from top-down urban development models that primarily benefits private landowners and towards citizen-led investment approaches. Since 2021, Charlie has collaborated on developing modular smart contracts that utilise simple bonding curves, one of which was deployed in 2023 through the Swiss Association he co-founded in Switzerland. He most recently led the Civic Tech Studio at Dark Matter Labs in which prototyping work provided valuable insights into decentralised finance mechanisms. In October 2024, Charlie was awarded the Just Open Source Grant to further explore neighbourhood wealth mechanisms in Berlin co-operative developments through novel blockchain technologies.</p>
           </section>
 
           <section>
@@ -109,7 +109,7 @@ export default function CharliePage() {
                 <ul className="list-disc list-inside space-y-2 text-gray-300">
                   <li>Reframing Conflict - One day training with Outlandish (2022)</li>
                   <li>Tools for the Regenerative Renaissance - 6 week course (2021)</li>
-                  <li>Organization Design Masterclass, Supermarkt Berlin (2020)</li>
+                  <li>Organisation Design Masterclass, Supermarkt Berlin (2020)</li>
                   <li>Pamwin Development Modelling Training, M3 (2020)</li>
                   <li>Accredited Community-led Housing Adviser with Chartered Institute of Housing (2018)</li>
                   <li>The One Planet Living Framework, Training, Oxford (2017)</li>

--- a/app/[locale]/team/clara/page.tsx
+++ b/app/[locale]/team/clara/page.tsx
@@ -28,7 +28,7 @@ export default function ClaraPage() {
           <section>
             <h2 className="text-2xl font-semibold mb-4">About</h2>
             <p className="text-gray-300 mb-4">Barcelona, Spain, 1990</p>
-            <p className="text-gray-300 mb-4">With a background as regen architect and social housing incubator I leverage the power of self-organization and decentralized technology to bring housing and land commons to mainstream to advance into having more fair, regen and sovereign societies.</p>
+            <p className="text-gray-300 mb-4">With a background as regen architect and social housing incubator I leverage the power of self-organisation and decentralised technology to bring housing and land commons to mainstream to advance into having more fair, regen and sovereign societies.</p>
           </section>
 
           <section>
@@ -37,12 +37,12 @@ export default function ClaraPage() {
               <div>
                 <h3 className="text-xl font-medium">Community-Led Housing & Blockchain Consultant</h3>
                 <p className="text-gray-300">Independent, remote | Jan 2024-Present</p>
-                <p className="text-gray-300">Advising organizations, start-ups and entrepreneurs on their community-led housing (co-living, pop-up cities, permanent residences) projects using blockchain enabled mechanisms.</p>
+                <p className="text-gray-300">Advising organisations, start-ups and entrepreneurs on their community-led housing (co-living, pop-up cities, permanent residences) projects using blockchain enabled mechanisms.</p>
               </div>
               <div>
                 <h3 className="text-xl font-medium">DAO People Ops & Operations Lead</h3>
                 <p className="text-gray-300">deng service DAO, remote | December 2021-Present</p>
-                <p className="text-gray-300">Leading system improvements for enhanced member and client success, business development strategies and partnerships, org cross-team coordination, and optimizing DAO governance as organization runs as a workers co-operative.</p>
+                <p className="text-gray-300">Leading system improvements for enhanced member and client success, business development strategies and partnerships, org cross-team coordination, and optimising DAO governance as organisation runs as a workers co-operative.</p>
               </div>
               <div>
                 <h3 className="text-xl font-medium">Co-founder, Product Design</h3>

--- a/app/[locale]/team/rita/page.tsx
+++ b/app/[locale]/team/rita/page.tsx
@@ -28,7 +28,7 @@ export default function RitaPage() {
           <section>
             <h2 className="text-2xl font-semibold mb-4">About</h2>
             <p className="text-gray-300 mb-4">Artist and Researcher</p>
-            <p className="text-gray-300 mb-4">Rita is an artist and researcher whose work centers on multispecies perspectives within organisational contexts. She explores the convergence of art and sustainability, developing creative and transdisciplinary experiences to challenge conventional paradigms and cultivate new imaginaries for transformative change.</p>
+            <p className="text-gray-300 mb-4">Rita is an artist and researcher whose work centres on multispecies perspectives within organisational contexts. She explores the convergence of art and sustainability, developing creative and transdisciplinary experiences to challenge conventional paradigms and cultivate new imaginaries for transformative change.</p>
           </section>
 
           <section>

--- a/lib/messages/home.ts
+++ b/lib/messages/home.ts
@@ -50,7 +50,7 @@ const en: HomeMessages = {
       key: "wealth",
       heading: "Inverting Civic Wealth",
       description:
-        "Supporting communities through co-designing innovative economic tools to enhance control over housing and land ownership. Pooled funding, community-driven exit strategies, multi-capital currencies, and bioregional banking reshape how wealth flows within neighborhoods and interconnected communities.",
+        "Supporting communities through co-designing innovative economic tools to enhance control over housing and land ownership. Pooled funding, community-driven exit strategies, multi-capital currencies, and bioregional banking reshape how wealth flows within neighbourhoods and interconnected communities.",
     },
     {
       key: "agreements",


### PR DESCRIPTION
## Summary
- Adds a Franz Josef Allmayer block between Charlie and Clara in the home-page team grid, with LinkedIn link and bio (ixo, Hypha/SEEDS, Integrity.Earth).
- Shifts the fade-in delays of the team members after Franz by 100ms each so animation timing stays sequential.
- Converts the remaining American spellings to British English across team bios and home copy (neighbourhoods, centres, decentralised, human-centred, incentivisation, organisation/organisations, optimising, emphasising, utilise, self-organisation).

## Test plan
- [ ] Pull the branch and run `PORT=3001 npm run dev`.
- [ ] Open `/en` and `/de`, scroll to the team section, confirm Franz appears between Charlie and Clara with the correct bio and LinkedIn icon.
- [ ] Confirm the fade-in animations on Clara, Bradley, Livia, Jeff, Rita and Robert still feel sequential (no overlap, no gap).
- [ ] Spot-check the British English spellings on the home page intro and on `/team/charlie`, `/team/clara`, `/team/rita`.
- [ ] Confirm the partners section is unchanged (still the existing marquee with the existing logos).